### PR TITLE
Moved spdep to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,8 @@ Imports:
 	data.table (>= 1.12.2),
 	reshape2 (>= 1.4.3),
   shinyjs (>= 1.0),
-  ggiraph (>= 0.6)
+  ggiraph (>= 0.6),
+  spdep (>= 1.1)
 Remotes:
   linxihui/NNLM
 Suggests: 
@@ -64,8 +65,7 @@ Suggests:
 	Giotto (>= 0.1.4),
 	adespatial (>= 0.3),
 	sp (>= 1.3),
-	spData (>= 0.3.2),
-	spdep (>= 1.1)
+	spData (>= 0.3.2)
 VignetteBuilder: knitr
 RoxygenNote: 7.1.1
 Collate: 


### PR DESCRIPTION
Hi,

I have encountered a problem installing STutility from an empty **renv** project.
I think there is a problem with the "spdep" dependency.
The steps to reproduce the problem are the following:
1. From RStudio Console initialize empty project of renv: `renv::init(bare=T)` and R will then reboot with the load of the renv environment `* Project '/tmp/stutility-renv' loaded. [renv 0.13.2]`
2. Try to install STutility with renv: `renv::install("jbergenstrahle/STUtility")`
but it will display the following error `there is no package called 'spdep'`

So I forked your repo and I simply moved `spdep` in the Imports section.
By repeating the same steps, the installation from my fork it works.


